### PR TITLE
Adding more colors to the Sodaq Tracker

### DIFF
--- a/SodaqOneTracker/SodaqOneTracker.ino
+++ b/SodaqOneTracker/SodaqOneTracker.ino
@@ -90,7 +90,11 @@ enum LedColor {
     NONE = 0,
     RED,
     GREEN,
-    BLUE
+    BLUE,
+    YELLOW,
+    MAGENTA,
+    CYAN,
+    WHITE
 };
 
 
@@ -682,6 +686,23 @@ void setLedColor(LedColor color)
         digitalWrite(LED_GREEN, LOW);
         break;
     case BLUE:
+        digitalWrite(LED_BLUE, LOW);
+        break;
+    case YELLOW:
+        digitalWrite(LED_GREEN, LOW);
+        digitalWrite(LED_RED, LOW);
+        break;
+    case MAGENTA:
+        digitalWrite(LED_BLUE, LOW);
+        digitalWrite(LED_RED, LOW);
+        break;
+    case CYAN:
+        digitalWrite(LED_GREEN, LOW);
+        digitalWrite(LED_BLUE, LOW);
+        break;
+    case WHITE:
+        digitalWrite(LED_GREEN, LOW);
+        digitalWrite(LED_RED, LOW);
         digitalWrite(LED_BLUE, LOW);
         break;
     default:


### PR DESCRIPTION
This patch adds more colors to the Sodaq ONe by enabling more than one LED at a time (additive color mixing).

Signed-off-by: Simon Egli deadolus@gmail.com
