### PR TITLE
Update SodaqOneTracker.ino

### DIFF
--- a/SodaqOneTracker/SodaqOneTracker.ino
+++ b/SodaqOneTracker/SodaqOneTracker.ino
@@ -923,6 +923,8 @@ void setGpsActive(bool on)
         ublox.enable();
         ublox.flush();
 
+        sodaq_wdt_safe_delay(100); //delay Sodaq One V2
+        
         PortConfigurationDDC pcd;
         if (ublox.getPortConfigurationDDC(&pcd)) {
             pcd.outProtoMask = 1; // Disable NMEA


### PR DESCRIPTION
Starting up the Sodaq One V2 board I've noticed issue activating the GPS after a wake-up.
100ms delay solves the issue