### PR TITLE
Update SodaqOneTracker.ino, fixed out-of-bounds write.

### DIFF
--- a/SodaqOneTracker/SodaqOneTracker.ino
+++ b/SodaqOneTracker/SodaqOneTracker.ino
@@ -451,8 +451,6 @@ bool convertAndCheckHexArray(uint8_t* result, const char* hex, size_t resultSize
         outputIndex++;
     }
 
-    result[outputIndex] = 0; // terminate the string
-
     return foundNonZero;
 }
 


### PR DESCRIPTION
Fixed out-of-bounds write when converting hex to binary