### PR TITLE
add missing functionality for Led Enable/Disable

### DIFF
--- a/SodaqOneTracker/Config.cpp
+++ b/SodaqOneTracker/Config.cpp
@@ -97,6 +97,7 @@ void ConfigParams::reset()
     _powerIndex = 1;
     _isGpsOn = 1;
     _gpsMinSatelliteCount = 4;
+    _isLedEnabled = 0;
     _isDebugOn = 0;
 
     if (configResetCallback) {
@@ -237,6 +238,11 @@ bool ConfigParams::checkConfig(Stream& stream)
 
     if (_isGpsOn > 1) {
         stream.println("GPS must be either 0 or 1");
+        fail = true;
+    }
+
+    if (_isLedEnabled > 1) {
+        stream.println("Led must be either 0 or 1");
         fail = true;
     }
 

--- a/SodaqOneTracker/SodaqOneTracker.ino
+++ b/SodaqOneTracker/SodaqOneTracker.ino
@@ -92,6 +92,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define debugPrint(x) if (params.getIsDebugOn()) { DEBUG_STREAM.print(x); }
 #define debugPrintln(x) if (params.getIsDebugOn()) { DEBUG_STREAM.println(x); }
 
+#define setLedEnabledColor(x) if (params.getIsLedEnabled()) { setLedColor(x); }
 
 enum LedColor {
     NONE = 0,
@@ -237,7 +238,7 @@ void setup()
     }
 
     if (getGpsFixAndTransmit()) {
-        setLedColor(GREEN);
+        setLedEnabledColor(GREEN);
         sodaq_wdt_safe_delay(800);
     }
 }
@@ -250,7 +251,7 @@ void loop()
 
     if (minuteFlag) {
         if (params.getIsLedEnabled()) {
-            setLedColor(BLUE);
+            setLedEnabledColor(BLUE);
         }
 
         timer.update(); // handle scheduled events


### PR DESCRIPTION
While working on a 2G low power version of the SodaqOne-UniversalTracker I figured out that some functionality to switch on/off the leds from the setup menu was missing. Now leds work like Debug: they can be switched on/off through the setup menu.